### PR TITLE
fix: update generateDocSchemaConstants to return an empty string for …

### DIFF
--- a/libs/pg-meta/src/templates/typescript.ts
+++ b/libs/pg-meta/src/templates/typescript.ts
@@ -840,7 +840,7 @@ const generateDocSchemaConstants = (collections: CollectionsDoc[]): string => {
   })
 
   if (enumTypes.size === 0) {
-    return '[_ in never]: never'
+    return ''
   }
 
   return Array.from(enumTypes.entries())


### PR DESCRIPTION
…empty enum types

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed TypeScript code generation to properly handle schemas with no enum definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->